### PR TITLE
refactor : 검증로직 인터페이스와 구현체로 분리(SOLID 위반사례 검토)

### DIFF
--- a/src/main/java/com/sparta/uglymarket/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/uglymarket/order/controller/OrderController.java
@@ -6,6 +6,8 @@ import com.sparta.uglymarket.order.dto.OrderResponse;
 import com.sparta.uglymarket.order.dto.PendingReviewOrderResponse;
 import com.sparta.uglymarket.order.dto.WrittenReviewOrderResponse;
 import com.sparta.uglymarket.order.service.OrderService;
+import com.sparta.uglymarket.util.JwtUtil;
+import com.sparta.uglymarket.util.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,16 +20,18 @@ import java.util.List;
 public class OrderController {
 
     private final OrderService orderService;
+    private final TokenService tokenService;
 
-    public OrderController(OrderService orderService) {
+    public OrderController(OrderService orderService, TokenService tokenService) {
         this.orderService = orderService;
+        this.tokenService = tokenService;
     }
 
 
     //주문 생성
     @PostMapping
     public ResponseEntity<OrderResponse> createOrder(@RequestBody OrderRequest request, HttpServletRequest httpRequest) {
-        String phoneNumber = (String) httpRequest.getAttribute("phoneNumber");//헤더에서 폰번호 찾기
+        String phoneNumber = tokenService.getPhoneNumberFromRequest(httpRequest);//헤더에서 폰번호 찾기
 
         OrderResponse response = orderService.createOrder(request, phoneNumber);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
@@ -36,7 +40,7 @@ public class OrderController {
     // 사용자가 후기를 작성할 수 있는 주문 목록 조회
     @GetMapping("/user/pending-reviews")
     public ResponseEntity<List<PendingReviewOrderResponse>> getPendingReviewOrdersByUser(HttpServletRequest httpRequest) {
-        String phoneNumber = (String) httpRequest.getAttribute("phoneNumber");//헤더에서 폰번호 찾기
+        String phoneNumber = tokenService.getPhoneNumberFromRequest(httpRequest);//헤더에서 폰번호 찾기
 
         List<PendingReviewOrderResponse> orders = orderService.getPendingReviewOrdersByUserId(phoneNumber);
         return new ResponseEntity<>(orders, HttpStatus.OK);
@@ -45,7 +49,7 @@ public class OrderController {
     // 사용자가 후기를 작성한 주문 목록 조회
     @GetMapping("/user/written-reviews")
     public ResponseEntity<List<WrittenReviewOrderResponse>> getWrittenReviewOrdersByUser(HttpServletRequest httpRequest) {
-        String phoneNumber = (String) httpRequest.getAttribute("phoneNumber");//헤더에서 폰번호 찾기
+        String phoneNumber = tokenService.getPhoneNumberFromRequest(httpRequest);//헤더에서 폰번호 찾기
 
         List<WrittenReviewOrderResponse> orders = orderService.getWrittenReviewOrdersByUserId(phoneNumber);
         return new ResponseEntity<>(orders, HttpStatus.OK);

--- a/src/main/java/com/sparta/uglymarket/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/uglymarket/review/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.sparta.uglymarket.review.controller;
 
 import com.sparta.uglymarket.review.dto.*;
 import com.sparta.uglymarket.review.service.ReviewService;
+import com.sparta.uglymarket.util.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,16 +15,18 @@ import java.util.List;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final TokenService tokenService;
 
-    public ReviewController(ReviewService reviewService) {
+    public ReviewController(ReviewService reviewService, TokenService tokenService) {
         this.reviewService = reviewService;
+        this.tokenService = tokenService;
     }
 
 
     // 후기 등록
     @PostMapping
     public ResponseEntity<ReviewCreateResponse> createReview(@RequestBody ReviewCreateRequest request, HttpServletRequest httpRequest) {
-        String phoneNumber = (String) httpRequest.getAttribute("phoneNumber");
+        String phoneNumber = tokenService.getPhoneNumberFromRequest(httpRequest);//헤더에서 폰번호 찾기
         if (phoneNumber == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
@@ -35,7 +38,7 @@ public class ReviewController {
     //후기 삭제
     @DeleteMapping("/delete/{reviewId}")
     public ResponseEntity<ReviewDeleteResponse> deleteReview(@PathVariable Long reviewId, HttpServletRequest httpRequest) {
-        String phoneNumber = (String) httpRequest.getAttribute("phoneNumber");
+        String phoneNumber = tokenService.getPhoneNumberFromRequest(httpRequest);
         if (phoneNumber == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }

--- a/src/main/java/com/sparta/uglymarket/review/service/impl/DefaultReviewValidator.java
+++ b/src/main/java/com/sparta/uglymarket/review/service/impl/DefaultReviewValidator.java
@@ -1,0 +1,30 @@
+package com.sparta.uglymarket.review.service.impl;
+
+import com.sparta.uglymarket.exception.CustomException;
+import com.sparta.uglymarket.exception.ErrorMsg;
+import com.sparta.uglymarket.order.entity.Orders;
+import com.sparta.uglymarket.review.dto.ReviewCreateRequest;
+import com.sparta.uglymarket.review.entity.Review;
+import com.sparta.uglymarket.review.service.validator.ReviewValidator;
+import com.sparta.uglymarket.user.entity.User;
+
+public class DefaultReviewValidator implements ReviewValidator {
+
+    //주문의 유저아이디와, 토큰에서 가져온 유저의 아이디가 같은지 검증
+    @Override
+    public void validate(Orders orders, User user) {
+        if (!orders.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorMsg.UNAUTHORIZED_MEMBER);
+        }
+    }
+
+    //리뷰의 유저 아이디와, 토큰에서 가져온 유저 아이디가 같은지 검증
+    @Override
+    public void validateDeleteReview(User user, Review review) {
+        if (!review.getOrders().getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorMsg.UNAUTHORIZED_MEMBER);
+        }
+    }
+
+
+}

--- a/src/main/java/com/sparta/uglymarket/review/service/validator/ReviewValidator.java
+++ b/src/main/java/com/sparta/uglymarket/review/service/validator/ReviewValidator.java
@@ -1,0 +1,17 @@
+package com.sparta.uglymarket.review.service.validator;
+
+import com.sparta.uglymarket.order.entity.Orders;
+import com.sparta.uglymarket.product.entity.Product;
+import com.sparta.uglymarket.review.entity.Review;
+import com.sparta.uglymarket.user.entity.User;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public interface ReviewValidator {
+
+    void validate(Orders orders, User user);
+
+    void validateDeleteReview(User user, Review review);
+
+}

--- a/src/main/java/com/sparta/uglymarket/util/TokenService.java
+++ b/src/main/java/com/sparta/uglymarket/util/TokenService.java
@@ -1,0 +1,11 @@
+package com.sparta.uglymarket.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface TokenService {
+
+    String getPhoneNumberFromRequest(HttpServletRequest request);
+
+}

--- a/src/main/java/com/sparta/uglymarket/util/TokenServiceImpl.java
+++ b/src/main/java/com/sparta/uglymarket/util/TokenServiceImpl.java
@@ -1,0 +1,20 @@
+package com.sparta.uglymarket.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class TokenServiceImpl implements TokenService{
+
+    private final JwtUtil jwtUtil;
+
+    public TokenServiceImpl(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+
+    @Override
+    public String getPhoneNumberFromRequest(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        String token = header.substring(7);
+        return jwtUtil.getPhoneNumberFromToken(token);
+    }
+}


### PR DESCRIPTION
## 🛠️ 변경 사항
- SOLID 위반사항 및 검수 및 수정하였습니다.
- 토큰검증 메서드는 로그인 후에 사용하는 메서드에서 공통적으로 사용해야합니다.
- 개방 폐쇄 원칙을 지키기 위해 그리고 이후 검증메서드가 추가되거나 변경이 될때 직접적으로 코드를 수정하지 않도록  
토큰검증 메서드를 인터페이스와 구현체로 분리했습니다.


<br/>

## ⚡️ Issue number & Link
- #8 

<br/>