### PR TITLE
refactor : SOLID 비밀번호 인코딩과 매칭 기능을 유틸리티 클래스로 분리

### DIFF
--- a/src/main/java/com/sparta/uglymarket/util/PasswordEncoderUtil.java
+++ b/src/main/java/com/sparta/uglymarket/util/PasswordEncoderUtil.java
@@ -1,0 +1,25 @@
+package com.sparta.uglymarket.util;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoderUtil {
+
+    private final PasswordEncoder passwordEncoder;
+
+    public PasswordEncoderUtil() {
+        this.passwordEncoder = new BCryptPasswordEncoder();
+    }
+
+    //패스워드 인코딩
+    public String encodePassword(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    //입력된 비번과 인코딩된 비번이 같은지 검사
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
- 비밀번호 인코딩과 매칭 기능은 많은 클래스에서 사용할 것입니다. 
따라서 유틸리티 클래스로 분리 하여 사용하는 것이 알맞습니다.

<br/>

## ⚡️ Issue number & Link
- #17 

<br/>

## 📝 체크 리스트
- [x] 비밀번호 인코딩과 매칭 기능을 유틸리티 클래스로 분리

<br/>
