### PR TITLE
feat : server health-check 기능 추가

### DIFF
--- a/src/main/java/com/sparta/uglymarket/healthCheck/HealthCheckController.java
+++ b/src/main/java/com/sparta/uglymarket/healthCheck/HealthCheckController.java
@@ -1,0 +1,37 @@
+package com.sparta.uglymarket.healthCheck;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class HealthCheckController {
+
+    @Value(value="${server.env}")
+    private String env;
+    @Value(value="${server.port}")
+    private String serverPort;
+    @Value(value="${server.serveraddress}")
+    private String serverAddress;
+    @Value(value="${servername}")
+    private String serverName;
+
+    //현재 동작중인 서버 확인(blue, green)
+    //http://"serverIP"/hc
+    @GetMapping("/hc")
+    public ResponseEntity<?> healthCheck() {
+        Map<String,String> responeseData = new TreeMap<>();
+        responeseData.put("serverName",serverName);
+        responeseData.put("serverAddress",serverAddress);
+        responeseData.put("serverPort",serverPort);
+        responeseData.put("env",env);
+        return ResponseEntity.ok(responeseData);
+    }
+
+    @GetMapping("/env")
+    public ResponseEntity<?> getEnv(){
+        return ResponseEntity.ok(env);
+    }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
- server health-check 기능 추가하여 
무중단 배포를 했을때 서버가 실행되고 있는지 확인 할 수 있습니다.
- Green서버, Blue서버 중 어떤 서버가 구동되고 있는지를 확인할 수 있고
서버의 포트번호, 이름, 주소 등을 확인할 수 있습니다.

<br/>

## ⚡️ Issue number & Link
- #24 

<br/>

## 📝 체크 리스트
- [x] HealthCheckController추가

<br/>
