### PR TITLE
feat : SOLID  상품 서비스 단일책임 원칙 준수

### DIFF
--- a/src/main/java/com/sparta/uglymarket/product/service/ProductService.java
+++ b/src/main/java/com/sparta/uglymarket/product/service/ProductService.java
@@ -28,32 +28,34 @@ public class ProductService {
 
         //전체 상품 조회
         List<Product> products = productRepository.findAll();
-
-        //DTO를 담아줄 리스트
-        List<GetAllProductsResponse> responseList = new ArrayList<>();
-
-        for (Product product : products) { //for 문으로 엔티티를 하나씩 뽑아서
-            GetAllProductsResponse response = new GetAllProductsResponse(product); //DTO로 만들어주고
-
-            responseList.add(response);//리스트에 담아주기
-        }
-        return responseList; //리스트 반환
+        return convertToGetAllProductsResponseList(products);
     }
 
-    //특정 상품 조회
+    //특정 상품 세부조회
     public ProductResponse getProductById(long productId) {
 
         //특정 상품 조회
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(ErrorMsg.PRODUCT_NOT_FOUND));
 
-        //상품에 달려있는 리뷰들 조회하기
+        return convertToProductResponse(product);
+    }
+
+    //DTO 변환 메서드
+    private List<GetAllProductsResponse> convertToGetAllProductsResponseList(List<Product> products) {
+        List<GetAllProductsResponse> responseList = new ArrayList<>();
+        for (Product product : products) {
+            responseList.add(new GetAllProductsResponse(product));
+        }
+        return responseList;
+    }
+
+    ///DTO 변환 메서드, 상품에 달려있는 리뷰들 조회
+    private ProductResponse convertToProductResponse(Product product) {
         List<ReviewResponse> reviews = new ArrayList<>();
-        for (Review review : product.getReviews()) {
+        for (var review : product.getReviews()) {
             reviews.add(new ReviewResponse(review));
         }
-
-        //DTO로 만들어서 반환
         return new ProductResponse(product, reviews);
     }
 

--- a/src/main/java/com/sparta/uglymarket/review/service/validator/impl/DefaultReviewValidator.java
+++ b/src/main/java/com/sparta/uglymarket/review/service/validator/impl/DefaultReviewValidator.java
@@ -1,4 +1,4 @@
-package com.sparta.uglymarket.review.service.impl;
+package com.sparta.uglymarket.review.service.validator.impl;
 
 import com.sparta.uglymarket.exception.CustomException;
 import com.sparta.uglymarket.exception.ErrorMsg;


### PR DESCRIPTION
## 🛠️ 작업 내용
- 상품 도메인 관련 서비스에서 엔티티를 -> DTO로 변환하는 책임을 서비스 메서드가 들고있어서
 단일책임 원칙에 따라 변환 메서드를 따로 분리하였습니다.

<br/>

## ⚡️ Issue number & Link
- #17 

<br/>

## 📝 체크 리스트
- [ ] 상품 서비스 단일책임 원칙 준수

<br/>

