### PR TITLE
Test : JACOCO 도입 및 HealthCheck 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.sparta'
@@ -21,6 +22,34 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+tasks.jacocoTestReport {
+    dependsOn tasks.test
+    reports {
+        xml.required.set(true) // XML 리포트 생성
+        csv.required.set(false) // CSV 리포트는 생성하지 않음
+        html.required.set(true) // HTML 리포트 생성
+
+        // 리포트가 저장될 경로 설정
+        html.destination file("jacoco/jacocoHtml")
+        xml.destination file("jacoco/jacoco.xml")
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = 'CLASS' // 전체 프로젝트 단위로 체크
+
+            // 전체 커버리지의 최소값
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80 // 최소 커버리지 80%
+            }
+        }
+    }
 }
 
 dependencies {

--- a/src/test/java/com/sparta/uglymarket/healthCheck/HealthCheckControllerTest.java
+++ b/src/test/java/com/sparta/uglymarket/healthCheck/HealthCheckControllerTest.java
@@ -1,0 +1,62 @@
+package com.sparta.uglymarket.healthCheck;
+
+import com.sparta.uglymarket.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HealthCheckController.class)
+@TestPropertySource(properties = {
+        "server.env=local",
+        "server.port=8080",
+        "server.serveraddress=127.0.0.1",
+        "servername=testServer"
+})
+@AutoConfigureMockMvc(addFilters = false)  // 시큐리티 필터 비활성화
+class HealthCheckControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("헬스 체크 API 테스트")
+    void healthCheck_Success() throws Exception {
+        // expected 데이터
+        Map<String, String> expectedResponse = new TreeMap<>();
+        expectedResponse.put("serverName", "testServer");
+        expectedResponse.put("serverAddress", "127.0.0.1");
+        expectedResponse.put("serverPort", "8080");
+        expectedResponse.put("env", "local");
+
+        // when & then
+        mockMvc.perform(get("/hc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.serverName").value("testServer"))
+                .andExpect(jsonPath("$.serverAddress").value("127.0.0.1"))
+                .andExpect(jsonPath("$.serverPort").value("8080"))
+                .andExpect(jsonPath("$.env").value("local"));
+    }
+
+    @Test
+    @DisplayName("env 정보 반환 테스트")
+    void getEnv_Success() throws Exception {
+        // when & then
+        mockMvc.perform(get("/env"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("local"));
+    }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
- JACOCO 를 활용하여 테스트 커버리즈 특정에 도입하였습니다.
-  HealthCheck 테스트 코드를 작성하였습니다.

<br/>

## ⚡️ Issue number & Link
- #30 

<br/>

## 📝 체크 리스트
- [x] HealthCheck API 테스트
- [x] env 정보 반환 테스트

<br/>

