### PR TITLE
refactor : 리뷰 생성자 도메인계층에 알맞도록 수정

### DIFF
--- a/src/main/java/com/sparta/uglymarket/review/entity/Review.java
+++ b/src/main/java/com/sparta/uglymarket/review/entity/Review.java
@@ -33,7 +33,5 @@ public class Review {
         this.reviewImage = request.getReviewImage();
         this.orders = orders;
         this.product = product;
-        orders.markAsReviewed();// 리뷰 작성 시 주문의 reviewed 필드를 true로 설정
-
     }
 }

--- a/src/main/java/com/sparta/uglymarket/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/uglymarket/review/service/ReviewService.java
@@ -48,6 +48,9 @@ public class ReviewService {
 
         // 후기 생성
         Review review = new Review(request, orders, product);
+
+        orders.markAsReviewed(); // 주문의 상태를 서비스 계층에서 변경
+
         Review savedReview = reviewRepository.save(review);
 
         //dto로 변환 후 반환


### PR DESCRIPTION
## 🛠️ 작업 내용
- 도메인 계층에는 도메인의 핵심 비즈니스 로직이 있어야 합니다. 
- 다른 도메인 객체를 직접 수정하거나 상태를 변경하는 것은 
비즈니스 로직이지만 다른 도메인과 상호작용 하는 것 임으로 서비스 계층에서 이뤄줘야 합니다.
- 따라서 orders.markAsReviewed(); 메서드가 생성자에 있는것을 -> 서비스 계층으로 옮기게 되었습니다.

<br/>

## ⚡️ Issue number & Link
- #17 


<br/>

## 📝 체크 리스트
- [x] 리뷰 생성자의 주문도메인 상태변경 메서드를 서비스 계층으로 분리

<br/>

